### PR TITLE
Add remote imports for modules we migrate to monorepo.

### DIFF
--- a/common/index.html
+++ b/common/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Podman vanity import</title>
+    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/common">
+</head>
+<body>
+</body>
+</html>

--- a/image/index.html
+++ b/image/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Podman vanity import</title>
+    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=url=https://github.com/containers/container-libs/tree/main/image">
+</head>
+<body>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Podman vanity import</title>
+    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs">
+</head>
+<body>
+</body>
+</html>

--- a/storage/index.html
+++ b/storage/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Podman vanity import</title>
+    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/storage">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
This commit adds new static .html pages which contain the metadata for go remote imports.

This allows us to use for example podman.io/go/storage in the go.mod. Go then does HTTP query to podman.io/go/storage followed by the HTTP query to podman.io/go to find out the real URL for git repository.

If real person opens that URL in a browser, they are redirected to the source-codes of particular module.