### PR TITLE
Fix double "url=" in the image/ redirects

### DIFF
--- a/image/index.html
+++ b/image/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Podman vanity import</title>
     <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
-    <meta http-equiv="refresh" content="0; url=url=https://github.com/containers/container-libs/tree/main/image">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/image">
 </head>
 <body>
 </body>

--- a/image/v5/index.html
+++ b/image/v5/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Podman vanity import</title>
     <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
-    <meta http-equiv="refresh" content="0; url=url=https://github.com/containers/container-libs/tree/main/image">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/image">
 </head>
 <body>
 </body>


### PR DESCRIPTION
There most likely was a copy-paste issue resulting in the wrong `url=url=` refresh meta tag. The redirects for image/ were therefore broken.

This commit removes the extra `url=` and fixes this issue.

Fixes: #4