### PR TITLE
Add buildah and skopeo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # go.podman.io
 
 This repository contains github-pages served on https://go.podman.io/ to enable the golang remote imports feature: https://pkg.go.dev/cmd/go#hdr-Remote_import_paths.
+
+## Supported Repositories
+
+- **[buildah](https://github.com/containers/buildah)** - `go.podman.io/buildah`
+- **[skopeo](https://github.com/containers/skopeo)** - `go.podman.io/skopeo`
+- From [container-libs](https://github.com/containers/container-libs):
+  - **[common](https://github.com/containers/container-libs/tree/main/common)** - `go.podman.io/common`
+  - **[image](https://github.com/containers/container-libs/tree/main/image)** - `go.podman.io/image/v5`
+  - **[storage](https://github.com/containers/container-libs/tree/main/storage)** - `go.podman.io/storage`

--- a/buildah/index.html
+++ b/buildah/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Buildah vanity import</title>
+    <meta name="go-import" content="go.podman.io/buildah git https://github.com/containers/buildah.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/buildah">
+</head>
+<body>
+</body>
+</html>

--- a/skopeo/index.html
+++ b/skopeo/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Skopeo vanity import</title>
+    <meta name="go-import" content="go.podman.io/skopeo git https://github.com/containers/skopeo.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/skopeo">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Adding buildah and skopeo to go.podman.io to allow for organizational flexibility in the future. Podman will be done in a separate PR because it is a little more dicey.

Fixes: RUN-4549