### PR TITLE
Add podman redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains github-pages served on https://go.podman.io/ to enable 
 ## Supported Repositories
 
 - **[buildah](https://github.com/containers/buildah)** - `go.podman.io/buildah`
+- **[podman](https://github.com/containers/podman)** - `go.podman.io/podman/v6`
 - **[skopeo](https://github.com/containers/skopeo)** - `go.podman.io/skopeo`
 - From [container-libs](https://github.com/containers/container-libs):
   - **[common](https://github.com/containers/container-libs/tree/main/common)** - `go.podman.io/common`

--- a/podman/v6/index.html
+++ b/podman/v6/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Podman vanity import</title>
+    <meta name="go-import" content="go.podman.io/podman/v6 git https://github.com/containers/podman.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/containers/podman">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Add podman redicts to go.podman.io.  Both podman and podman/v6 are added similar to image.

Fixes: RUN-4549