### PR TITLE
Change repository references for cncf

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository contains github-pages served on https://go.podman.io/ to enable 
 
 ## Supported Repositories
 
-- **[buildah](https://github.com/containers/buildah)** - `go.podman.io/buildah`
-- **[podman](https://github.com/containers/podman)** - `go.podman.io/podman/v6`
-- **[skopeo](https://github.com/containers/skopeo)** - `go.podman.io/skopeo`
-- From [container-libs](https://github.com/containers/container-libs):
-  - **[common](https://github.com/containers/container-libs/tree/main/common)** - `go.podman.io/common`
-  - **[image](https://github.com/containers/container-libs/tree/main/image)** - `go.podman.io/image/v5`
-  - **[storage](https://github.com/containers/container-libs/tree/main/storage)** - `go.podman.io/storage`
+- **[buildah](https://github.com/podman-container-tools/buildah)** - `go.podman.io/buildah`
+- **[podman](https://github.com/podman-container-tools/podman)** - `go.podman.io/podman/v6`
+- **[skopeo](https://github.com/podman-container-tools/skopeo)** - `go.podman.io/skopeo`
+- From [container-libs](https://github.com/podman-container-tools/container-libs):
+  - **[common](https://github.com/podman-container-tools/container-libs/tree/main/common)** - `go.podman.io/common`
+  - **[image](https://github.com/podman-container-tools/container-libs/tree/main/image)** - `go.podman.io/image/v5`
+  - **[storage](https://github.com/podman-container-tools/container-libs/tree/main/storage)** - `go.podman.io/storage`

--- a/buildah/index.html
+++ b/buildah/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Buildah vanity import</title>
-    <meta name="go-import" content="go.podman.io/buildah git https://github.com/containers/buildah.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/buildah">
+    <meta name="go-import" content="go.podman.io/buildah git https://github.com/podman-container-tools/buildah.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/buildah">
 </head>
 <body>
 </body>

--- a/common/index.html
+++ b/common/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Podman vanity import</title>
-    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/common">
+    <meta name="go-import" content="go.podman.io git https://github.com/podman-container-tools/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/container-libs/tree/main/common">
 </head>
 <body>
 </body>

--- a/image/index.html
+++ b/image/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Podman vanity import</title>
-    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/image">
+    <meta name="go-import" content="go.podman.io git https://github.com/podman-container-tools/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/container-libs/tree/main/image">
 </head>
 <body>
 </body>

--- a/image/v5/index.html
+++ b/image/v5/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Podman vanity import</title>
-    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/image">
+    <meta name="go-import" content="go.podman.io git https://github.com/podman-container-tools/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/container-libs/tree/main/image">
 </head>
 <body>
 </body>

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Podman vanity import</title>
-    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs">
+    <meta name="go-import" content="go.podman.io git https://github.com/podman-container-tools/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/container-libs">
 </head>
 <body>
 </body>

--- a/podman/v6/index.html
+++ b/podman/v6/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Podman vanity import</title>
-    <meta name="go-import" content="go.podman.io/podman/v6 git https://github.com/containers/podman.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/podman">
+    <meta name="go-import" content="go.podman.io/podman/v6 git https://github.com/podman-container-tools/podman.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/podman">
 </head>
 <body>
 </body>

--- a/skopeo/index.html
+++ b/skopeo/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Skopeo vanity import</title>
-    <meta name="go-import" content="go.podman.io/skopeo git https://github.com/containers/skopeo.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/skopeo">
+    <meta name="go-import" content="go.podman.io/skopeo git https://github.com/podman-container-tools/skopeo.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/skopeo">
 </head>
 <body>
 </body>

--- a/storage/index.html
+++ b/storage/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Podman vanity import</title>
-    <meta name="go-import" content="go.podman.io git https://github.com/containers/container-libs.git">
-    <meta http-equiv="refresh" content="0; url=https://github.com/containers/container-libs/tree/main/storage">
+    <meta name="go-import" content="go.podman.io git https://github.com/podman-container-tools/container-libs.git">
+    <meta http-equiv="refresh" content="0; url=https://github.com/podman-container-tools/container-libs/tree/main/storage">
 </head>
 <body>
 </body>


### PR DESCRIPTION
Due to CNCF requirements, the podman, buildah, skopeo, and container-libs repositories were moved from github.com/containers to github.com/podman-container-tools.